### PR TITLE
README: TikTok parity, missing tools, SDK + CLI, discovery surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-blue)](https://registry.modelcontextprotocol.io/?q=xpoz)
 [![Website](https://img.shields.io/badge/xpoz.ai-visit-green)](https://xpoz.ai)
 
-> **Remote MCP server** — no local installation required. Connect via Streamable HTTP and authenticate with Google OAuth.
+> **Remote MCP server** — no local installation required. Connect via Streamable HTTP and authenticate with OAuth 2.1 (sign in with Google, no API keys to manage). Direct probes to `https://mcp.xpoz.ai/mcp` return `401 Unauthorized` — that's expected; your MCP client handles the OAuth flow.
 
 ## Quick Start
 
@@ -24,13 +24,36 @@ Add to your MCP config:
 }
 ```
 
+### Claude Code, Codex, Gemini CLI
+
+```bash
+# Claude Code
+claude mcp add --transport http --scope user xpoz https://mcp.xpoz.ai/mcp
+
+# Codex / Gemini CLI: see https://www.xpoz.ai/integrations
+```
+
 ### OpenClaw
 
 ```bash
 clawhub install xpoz-social-search
 ```
 
-Then authenticate via the OAuth link when prompted.
+Then authenticate via the OAuth link when prompted. Eight more pre-built skills are available — see [`clawhub.ai/u/atyachin`](https://clawhub.ai/u/atyachin).
+
+---
+
+## SDKs & CLI
+
+If you'd rather call Xpoz directly from code or a terminal instead of through an MCP client:
+
+| Tool | Install | Source |
+|---|---|---|
+| TypeScript / Node.js | `npm install @xpoz/xpoz` | [`XPOZpublic/xpoz-ts-sdk`](https://github.com/XPOZpublic/xpoz-ts-sdk) |
+| Python | `pip install xpoz` | [`XPOZpublic/xpoz-python-sdk`](https://github.com/XPOZpublic/xpoz-python-sdk) |
+| CLI (any platform) | `brew install XPOZpublic/xpoz/xpoz-cli` | [`XPOZpublic/xpoz-cli`](https://github.com/XPOZpublic/xpoz-cli) |
+
+All three speak the same MCP protocol against `https://mcp.xpoz.ai/mcp` under the hood, so any tool you see below is reachable from every surface. Get an API token at [`xpoz.ai/get-token`](https://www.xpoz.ai/get-token).
 
 ---
 
@@ -69,7 +92,7 @@ Then authenticate via the OAuth link when prompted.
 | `getInstagramPostInteractingUsers` | Users who liked/commented on a post |
 | `getInstagramCommentsByPostId` | Get comments on a post |
 
-### Reddit (6 tools)
+### Reddit (9 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -79,8 +102,31 @@ Then authenticate via the OAuth link when prompted.
 | `getRedditPostsByKeywords` | Search posts across subreddits |
 | `getRedditPostWithCommentsById` | Get a post with its comment tree |
 | `getRedditCommentsByKeywords` | Search comments by keywords |
+| `searchRedditSubreddits` | Find subreddits by name |
+| `getRedditSubredditWithPostsByName` | Get a subreddit's metadata and recent posts |
+| `getRedditSubredditsByKeywords` | Discover subreddits by topic |
 
-### TikTok (coming soon)
+### TikTok (7 tools)
+
+| Tool | Description |
+|------|-------------|
+| `searchTiktokUsers` | Find creators by name or username |
+| `getTiktokUser` | Get creator profile (followers, likes, bio, verification) |
+| `getTiktokUsersByKeywords` | Discover creators by topic in their post history |
+| `getTiktokPostsByKeywords` | Search videos by keywords or hashtags |
+| `getTiktokPostsByUser` | Get videos posted by a specific creator |
+| `getTiktokPostsByIds` | Fetch specific videos by ID |
+| `getTiktokCommentsByPostId` | Get comments on a specific video |
+
+### Tracking & Monitoring (3 tools)
+
+For continuous brand monitoring and lead generation — Xpoz indexes new matching content as it appears.
+
+| Tool | Description |
+|------|-------------|
+| `addTrackedItems` | Subscribe to ongoing monitoring of a query, user, or subreddit across any platform |
+| `getTrackedItems` | List your active tracked items with last-update timestamps |
+| `removeTrackedItems` | Stop monitoring tracked items by ID |
 
 ---
 
@@ -92,7 +138,7 @@ Then authenticate via the OAuth link when prompted.
 - **Field selection** — request only the fields you need
 - **Cache control** — `forceLatest: true` bypasses cache for real-time data
 - **Async operations** — long-running exports with status polling
-- **OAuth 2.1** — secure Google OAuth authentication, no API keys to manage
+- **OAuth 2.1** — dynamic client registration with Google as the upstream identity provider, no API keys to manage
 
 ## Use Cases
 
@@ -105,9 +151,29 @@ Then authenticate via the OAuth link when prompted.
 
 ## Pricing
 
-- **Free tier** available
-- Plans from **$20/mo** — includes all platforms and tools
-- See [xpoz.ai/pricing](https://www.xpoz.ai/pricing) for details
+| Plan | Price | Monthly results | Tracked items |
+|---|---|---|---|
+| Free | $0 | 100,000 | 1 |
+| Pro | $20/mo | 1,000,000 | 10 |
+| Max | $200/mo | 10,000,000 | 30 |
+| Enterprise | custom | custom | custom |
+
+All platforms and tools are included on every paid plan. See [xpoz.ai/pricing](https://www.xpoz.ai/pricing) and [xpoz.ai/rate-limits](https://www.xpoz.ai/rate-limits) for full details.
+
+## Discovery surfaces (for AI agents and scanners)
+
+These public, machine-readable endpoints describe Xpoz to crawlers and agentic clients:
+
+| Surface | URL |
+|---|---|
+| MCP manifest | https://www.xpoz.ai/.well-known/mcp.json |
+| MCP tool catalog (descriptions + JSON-Schema parameters) | https://www.xpoz.ai/.well-known/mcp/tools.json |
+| Agent Skills index (agentskills.io v0.2.0) | https://www.xpoz.ai/.well-known/agent-skills/index.json |
+| `llms.txt` | https://www.xpoz.ai/llms.txt |
+| `llms-full.txt` | https://www.xpoz.ai/llms-full.txt |
+| `discovery.txt` | https://www.xpoz.ai/discovery.txt |
+| Webhooks contract | https://www.xpoz.ai/webhooks |
+| Rate limits & 429 contract | https://www.xpoz.ai/rate-limits |
 
 ## Links
 
@@ -115,6 +181,8 @@ Then authenticate via the OAuth link when prompted.
 - 📦 [MCP Registry](https://registry.modelcontextprotocol.io/?q=xpoz)
 - 🛠️ [ClawHub Skills](https://clawhub.ai/u/atyachin)
 - 📖 [Documentation](https://help.xpoz.ai)
+- 🐙 [XPOZpublic on GitHub](https://github.com/XPOZpublic) — TS SDK, Python SDK, CLI, agent skills, cookbooks
+- 🍺 [Homebrew tap](https://github.com/XPOZpublic/homebrew-xpoz)
 
 ## License
 


### PR DESCRIPTION
## Summary

Brings the public README in line with the deployed MCP server and the agent-readiness work that's now live on xpoz.ai.

The README is the public landing page that users and AI agents reach when searching \"xpoz mcp github\". It was understating platform parity (saying TikTok was \"coming soon\" when it's been live), missing several deployed tools, and not surfacing any of the alternative integration paths or discovery endpoints.

## What changed

### Platform parity
- **TikTok**: replaced \"(coming soon)\" with the live 7-tool table.
- **Reddit**: added 3 subreddit tools (\`searchRedditSubreddits\`, \`getRedditSubredditWithPostsByName\`, \`getRedditSubredditsByKeywords\`). Count 6 → 9.
- **New Tracking & Monitoring section**: documents \`addTrackedItems\`, \`getTrackedItems\`, \`removeTrackedItems\` — the tools that power continuous brand monitoring.

### Integration paths beyond MCP
- New **SDKs & CLI** section: \`@xpoz/xpoz\` (npm), \`xpoz\` (PyPI), \`xpoz-cli\` (Homebrew tap).
- New install snippet for Claude Code / Codex / Gemini CLI.
- OpenClaw section now mentions there are eight more pre-built skills.

### Discovery for AI agents and scanners
- New **Discovery surfaces** section linking the well-known endpoints on xpoz.ai: MCP manifest, MCP tool catalog (with JSON-Schema parameters), agent-skills index (agentskills.io v0.2.0), \`llms.txt\`, \`llms-full.txt\`, \`discovery.txt\`, \`/webhooks\`, \`/rate-limits\`. None of these were linked from the README before.

### Smaller fixes
- OAuth phrasing: \"Google OAuth\" → \"OAuth 2.1 with dynamic client registration (Google as upstream IdP)\".
- Added a note that direct probes to \`mcp.xpoz.ai/mcp\` return \`401\` by design (OAuth-gated) — heads off a confusion source.
- Pricing teaser → 4-row table (Free / Pro / Max / Enterprise) with monthly results and tracked-items counts.
- Links section: added XPOZpublic org index and Homebrew tap.

## Diff stats

\`\`\`
README.md | 84 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++------
1 file changed, 76 insertions(+), 8 deletions(-)
\`\`\`

## Test plan

- [ ] Render check: GitHub markdown rendering is correct
- [ ] All 25 links resolve (verified locally — only \`mcp.xpoz.ai/mcp\` returns 401, which is expected and the README explains it)
- [ ] Tool names match \`https://www.xpoz.ai/.well-known/mcp.json\`
- [ ] Tool counts: Twitter 14, Instagram 9, Reddit 9, TikTok 7, Tracking 3